### PR TITLE
Also use "Cookie" header as a source of cookies, e.g. to support Firefox

### DIFF
--- a/google-play-book-downloader-epub.py
+++ b/google-play-book-downloader-epub.py
@@ -112,17 +112,6 @@ def fetch_segment(url):
     return response
 
 
-# Firefox puts the cookies in the headers directly instead of using curl's --cookies/-b parameters
-if "Cookie" in headers:
-    if cookies:
-        logging.warning(f"Cookies appear in both --cookie argument and headers, check the cURL request in curl.txt")
-    cookie_header = headers["Cookie"]
-    cookie_parts = cookie_header.split(";")
-    for cookie in cookie_parts:
-        if "=" in cookie:
-            key, value = cookie.split("=", 1)
-            cookies[key.strip()] = value.strip()
-
 book_dir = f"books/{BOOK_ID}"
 os.makedirs(book_dir, exist_ok=True)
 os.chdir(book_dir)

--- a/google-play-book-downloader-epub.py
+++ b/google-play-book-downloader-epub.py
@@ -112,6 +112,17 @@ def fetch_segment(url):
     return response
 
 
+# Firefox puts the cookies in the headers directly instead of using curl's --cookies/-b parameters
+if "Cookie" in headers:
+    if cookies:
+        logging.warning(f"Cookies appear in both --cookie argument and headers, check the cURL request in curl.txt")
+    cookie_header = headers["Cookie"]
+    cookie_parts = cookie_header.split(";")
+    for cookie in cookie_parts:
+        if "=" in cookie:
+            key, value = cookie.split("=", 1)
+            cookies[key.strip()] = value.strip()
+
 book_dir = f"books/{BOOK_ID}"
 os.makedirs(book_dir, exist_ok=True)
 os.chdir(book_dir)

--- a/google-play-book-downloader-pdf.py
+++ b/google-play-book-downloader-pdf.py
@@ -194,11 +194,18 @@ def parse_curl_command(curl_command: str):
             key, value = header.split(":", 1)
             headers[key.strip()] = value.strip()
 
+    cookies_unparsed = args.cookies
     cookies = {}
-    if not args.cookies:
+    if "Cookie" in headers:
+        if args.cookies:
+            logging.warning(f"Cookies appear in both --cookie argument and headers, check the cURL request in curl.txt")
+            cookies_unparsed.append(headers["Cookie"])
+        else:
+            cookies_unparsed = [headers["Cookie"]]
+    if not cookies_unparsed:
         logging.error(f"No cookies detected in curl.txt! You didn't properly copy the cURL request to curl.txt so the book will not be able to download correctly")
     else:
-        for cookie in args.cookies:
+        for cookie in cookies_unparsed:
             cookie_parts = cookie.split(";")
             for cookie in cookie_parts:
                 if "=" in cookie:

--- a/google-play-book-downloader-pdf.py
+++ b/google-play-book-downloader-pdf.py
@@ -196,6 +196,7 @@ def parse_curl_command(curl_command: str):
 
     cookies_raw = args.cookies or []
     cookies = {}
+    # Firefox puts the cookies in the headers directly instead of using curl's --cookies/-b parameters
     if "Cookie" in headers:
         if cookies_raw:
             logging.warning(f"Cookies appear in both --cookie argument and headers, check the cURL request in curl.txt")

--- a/google-play-book-downloader-pdf.py
+++ b/google-play-book-downloader-pdf.py
@@ -201,7 +201,7 @@ def parse_curl_command(curl_command: str):
         if cookies_raw:
             logging.warning(f"Cookies appear in both --cookie argument and headers, check the cURL request in curl.txt")
         cookies_raw.append(headers["Cookie"])
-    
+
     if not cookies_raw:
         logging.error(f"No cookies detected in curl.txt! You didn't properly copy the cURL request to curl.txt so the book will not be able to download correctly")
     else:

--- a/google-play-book-downloader-pdf.py
+++ b/google-play-book-downloader-pdf.py
@@ -194,18 +194,17 @@ def parse_curl_command(curl_command: str):
             key, value = header.split(":", 1)
             headers[key.strip()] = value.strip()
 
-    cookies_unparsed = args.cookies
+    cookies_raw = args.cookies or []
     cookies = {}
     if "Cookie" in headers:
-        if args.cookies:
+        if cookies_raw:
             logging.warning(f"Cookies appear in both --cookie argument and headers, check the cURL request in curl.txt")
-            cookies_unparsed.append(headers["Cookie"])
-        else:
-            cookies_unparsed = [headers["Cookie"]]
-    if not cookies_unparsed:
+        cookies_raw.append(headers["Cookie"])
+    
+    if not cookies_raw:
         logging.error(f"No cookies detected in curl.txt! You didn't properly copy the cURL request to curl.txt so the book will not be able to download correctly")
     else:
-        for cookie in cookies_unparsed:
+        for cookie in cookies_raw:
             cookie_parts = cookie.split(";")
             for cookie in cookie_parts:
                 if "=" in cookie:


### PR DESCRIPTION
Great script! I noticed a small issue when trying it out, which is that Firefox on macOS at least seems to give you the cookies as a header rather than as a `--cookie` argument. Here's a fix if you like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cookie values can now be read from HTTP headers as well as from command-line arguments; values from both sources are merged when present.

* **Bug Fixes**
  * Missing-cookie cases now produce clearer errors when no cookie source is available.
  * A warning is shown when cookies are supplied from multiple sources simultaneously.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds compatibility for Firefox-exported cURL by extracting cookies from the `Cookie` header and merging them with `--cookie` args.
> 
> - Parse `Cookie` header when present and append to cookie list; warn if both sources are used
> - Preserve existing header parsing and improve robustness of cookie extraction with clearer error logging when none are found
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a08226edfaa2344c71fd9529f9514a03a247394d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->